### PR TITLE
ci: add install-docker.sh

### DIFF
--- a/install-docker.sh
+++ b/install-docker.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set +eux
+
+# https://docs.docker.com/engine/install/ubuntu/
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+# Install docker
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Install NVidia docker engine runtime
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+
+# Rootless mode
+sudo apt-get install -y dbus-user-session
+sudo systemctl stop docker docker.socket
+sudo systemctl disable --now docker.service docker.socket
+
+sudo dockerd-rootless-setuptool.sh install
+dockerd-rootless-setuptool.sh install
+systemctl --user start docker
+systemctl --user enable docker
+sudo loginctl enable-linger $(whoami)
+
+# Configuring Docker NVidia
+nvidia-ctk runtime configure --runtime=docker --config=$HOME/.config/docker/daemon.json
+systemctl --user restart docker
+sudo nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place
+
+docker run -it --rm --gpus all ubuntu nvidia-smi

--- a/install-docker.sh
+++ b/install-docker.sh
@@ -35,6 +35,8 @@ sudo systemctl disable --now docker.service docker.socket
 
 sudo dockerd-rootless-setuptool.sh install
 dockerd-rootless-setuptool.sh install
+mv ~/.docker /mnt/
+ln -s /mnt/.docker ~/.docker
 systemctl --user start docker
 systemctl --user enable docker
 sudo loginctl enable-linger $(whoami)

--- a/install-docker.sh
+++ b/install-docker.sh
@@ -29,11 +29,11 @@ sudo apt-get update
 sudo apt-get install -y nvidia-container-toolkit
 
 # Rootless mode
+# https://docs.docker.com/engine/security/rootless/
 sudo apt-get install -y dbus-user-session
 sudo systemctl stop docker docker.socket
 sudo systemctl disable --now docker.service docker.socket
 
-sudo dockerd-rootless-setuptool.sh install
 dockerd-rootless-setuptool.sh install
 mv ~/.docker /mnt/
 ln -s /mnt/.docker ~/.docker
@@ -47,3 +47,4 @@ systemctl --user restart docker
 sudo nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place
 
 docker run -it --rm --gpus all ubuntu nvidia-smi
+


### PR DESCRIPTION
### Motivation

Docker is a best practice to ensure reproducibility and isolation.

This small script to install docker with nvidia capability properly on a fresh VMs after `setup.sh`, `install-cuda.sh`.

In the context of https://github.com/ggerganov/llama.cpp/issues/6233