### PR TITLE
ci: upgrade github runner

### DIFF
--- a/images/github-runner/Dockerfile
+++ b/images/github-runner/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux ; \
       cuda-nvcc-12-2 \
       libcublas-dev-12-2;
 
-ARG RUNNER_VERSION=2.314.1
+ARG RUNNER_VERSION=2.316.0
 ARG RUNNER_VERSION_HASH=6c726a118bbe02cd32e222f890e1e476567bf299353a96886ba75b423c1137b5
 
 RUN set -eux ; \


### PR DESCRIPTION
### Motivation

This is to fix warnings:
https://github.com/ggerganov/llama.cpp/actions/runs/8841077544

Note: It is important to keep github runner up to date, probably later the installation should be done at each start of a runner.